### PR TITLE
[eventhubs-checkpointstore-table] fix live tests

### DIFF
--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -197,6 +197,14 @@
     }
   ],
   "outputs": {
+    "STORAGE_ACCOUNT_NAME": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    },
+    "STORAGE_ACCOUNT_KEY": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), variables('storageApiVersion')).keys[0].value]"
+    },
     "EVENTHUB_NAME": {
       "type": "string",
       "value": "[variables('eventHubName')]"


### PR DESCRIPTION
This change fixes the `@azure/eventhubs-checkpointstore-table` live tests by exposing the STORAGE_ACCOUNT_NAME and STORAGE_ACCOUNT_KEY environment variables used by the test.